### PR TITLE
Add Jest tests for API root

### DIFF
--- a/index.js
+++ b/index.js
@@ -1931,8 +1931,10 @@ app.post('/debug/award-founder', async (req, res) => {
 
 
 
-app.listen(PORT, () => {
-  console.log(`🚀 Server is running on port ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`🚀 Server is running on port ${PORT}`);
+  });
+}
 
-module.exports = { verifyToken };
+module.exports = { app, verifyToken };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -28,5 +28,9 @@
     "url": "https://github.com/AZumD/bradspelsmeny-backend/issues"
   },
   "homepage": "https://github.com/AZumD/bradspelsmeny-backend#readme",
-  "description": ""
+  "description": "",
+  "devDependencies": {
+    "jest": "^30.0.1",
+    "supertest": "^7.1.1"
+  }
 }

--- a/test/root.test.js
+++ b/test/root.test.js
@@ -1,0 +1,13 @@
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test_secret';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost:5432/testdb';
+
+const request = require('supertest');
+const { app } = require('../index');
+
+describe('GET /', () => {
+  it('should return status message', async () => {
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toBe('🎲 Board Game Backend API is running.');
+  });
+});


### PR DESCRIPTION
## Summary
- export Express `app` for testing
- configure Jest and Supertest
- test the root API route
- add `test` npm script

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853d76ae2708320b3f2badd28181aa5