### PR TITLE
Fix party session route conflict

### DIFF
--- a/index.js
+++ b/index.js
@@ -1424,7 +1424,8 @@ app.post('/party-session/:id/round', verifyToken, async (req, res) => {
 });
 
 
-app.get('/party/:id/sessions', verifyToken, async (req, res) => {
+// Fetch all sessions for a party
+app.get('/party/:id/all-sessions', verifyToken, async (req, res) => {
   const { id } = req.params;
 
   try {


### PR DESCRIPTION
## Summary
- split active vs past sessions at `/party/:id/sessions`
- rename full session list to `/party/:id/all-sessions`

## Testing
- `JWT_SECRET=test DATABASE_URL=sqlite3:///tmp/test.sqlite node index.js`

------
https://chatgpt.com/codex/tasks/task_e_6853d764dd588320a14c3ef74adc80da